### PR TITLE
Fix baseurl and deprecdated names

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
                     </div>
                     </br>
                     <h4>
-                        <a href="/post/">Archive</a>
+                        <a href="{{ .Site.BaseURL }}/post/">Archive</a>
                     </h4>
                 </section>
             </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,15 +6,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
     <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="{{ .Site.BaseUrl }}/css/uno.min.css" />
-    <link rel="stylesheet" type="text/css" href="{{ .Site.BaseUrl }}/css/lightGallery.css" />
+    <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/css/uno.min.css" />
+    <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/css/lightGallery.css" />
     <!-- Icons -->
     <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">
     <link rel="shortcut icon" href="/favicon.ico">
     <!-- RSS -->
     <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     <!-- Script -->
-    <script src="{{ .Site.BaseUrl }}/js/jquery.min.js"></script>
-    <script src="{{ .Site.BaseUrl }}/js/main.min.js">
+    <script src="{{ .Site.BaseURL }}/js/jquery.min.js"></script>
+    <script src="{{ .Site.BaseURL }}/js/main.min.js">
     </script>
 </head>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -7,9 +7,9 @@
     <div class="panel-main">
         <div class="panel-main__inner panel-inverted">
             <div class="panel-main__content"> {{ if .Site.Params.logo }}
-                <a href="{{ .Site.BaseURL }}" title="link to homepage for {{ .Site.Title }}"> <img src="{{ .Site.Params.logo }}" width="80" alt="{{ .Site.Title }} logo" class="panel-cover__logo logo" /> </a> {{ end }}
+                <a href="{{ .Site.BaseURL }}/" title="link to homepage for {{ .Site.Title }}"> <img src="{{ .Site.Params.logo }}" width="80" alt="{{ .Site.Title }} logo" class="panel-cover__logo logo" /> </a> {{ end }}
                 <h1 class="panel-cover__title panel-title">
-                    <a href="{{ .Site.BaseURL }}"  title="link to homepage for {{ .Site.Title }}">{{ .Site.Title }}</a>
+                    <a href="{{ .Site.BaseURL }}/"  title="link to homepage for {{ .Site.Title }}">{{ .Site.Title }}</a>
                 </h1>
                 <hr class="panel-cover__divider" />
                 <p class="panel-cover__description"> {{ if .Site.Params.description }} {{ .Site.Params.description }} {{ else }} This site is built using <a href="http://gohugo.io">hugo</a> and the theme is built by <a href="http://fredrikloch.me">Fredrik</a> if you enjoy it, it is available at <a href="https://github.com/SenjinDarashiva/hugo-uno">github</a> {{end}} </p>
@@ -17,7 +17,7 @@
                 <div class="navigation-wrapper">
                     <nav class="cover-navigation cover-navigation--primary">
                         <ul class="navigation">
-                            <li class="navigation__item"><a href="/#blog" title="link to {{ .Site.Title }} blog" class="blog-button">Blog</a> </li>
+                            <li class="navigation__item"><a href="{{ .Site.BaseURL }}/#blog" title="link to {{ .Site.Title }} blog" class="blog-button">Blog</a> </li>
                             </br> {{ if .Site.Params.cv }}
                             <li class="navigation__item"><a href="{{ .Site.Params.cv  }}" title="link to my CV " class="blog-button">CV</a> </li>
                             </br> {{ end }} </ul>
@@ -36,9 +36,9 @@
         <div class="panel-main">
             <div class="panel-main__inner panel-inverted">
                 <div class="panel-main__content"> {{ if .Site.Params.logo }}
-                    <a href="{{ .Site.BaseURL }}" title="link to homepage for {{ .Site.Title }}"> <img src="{{ .Site.Params.logo }}" width="80" alt="{{ .Site.Title }} logo" class="panel-cover__logo logo" /> </a> {{ end }}
+                    <a href="{{ .Site.BaseURL }}/" title="link to homepage for {{ .Site.Title }}"> <img src="{{ .Site.Params.logo }}" width="80" alt="{{ .Site.Title }} logo" class="panel-cover__logo logo" /> </a> {{ end }}
                     <h1 class="panel-cover__title panel-title">
-                        <a href="{{ .Site.BaseURL }}"  title="link to homepage for {{ .Site.Title }}">{{ .Site.Title }}</a>
+                        <a href="{{ .Site.BaseURL }}/"  title="link to homepage for {{ .Site.Title }}">{{ .Site.Title }}</a>
                     </h1>
                     <hr class="panel-cover__divider" />
                     <p class="panel-cover__description"> {{ if .Site.Params.description }} {{ .Site.Params.description }} {{ else }} This site is built using <a href="http://gohugo.io">hugo</a> and the theme is built by <a href="http://fredrikloch.me">Fredrik</a> if you enjoy it, it is available at <a href="https://github.com/SenjinDarashiva/hugo-uno">github</a> {{end}} </p>
@@ -46,7 +46,7 @@
                     <div class="navigation-wrapper">
                         <nav class="cover-navigation cover-navigation--primary">
                             <ul class="navigation">
-                                <li class="navigation__item"><a href="/#blog" title="link to {{ .Site.Title }} blog" class="blog-button">Blog</a> </li>
+                                <li class="navigation__item"><a href="{{ .Site.BaseURL }}/#blog" title="link to {{ .Site.Title }} blog" class="blog-button">Blog</a> </li>
                                 </br> {{ if .Site.Params.cv }}
                                 <li class="navigation__item"><a href="{{ .Site.Params.cv  }}" title="link to my CV " class="blog-button">CV</a> </li>
                                 </br> {{ end }} </ul>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -3,13 +3,13 @@
         <i class="fa fa-times btn-mobile-close__icon hidden"> </i>
     </span>
 
-<header class="{{ if .IsNode }} {{ if eq .Url "/post/" }} panel-cover panel-cover--collapsed {{ else }}panel-cover {{ end }}{{ else }}panel-cover panel-cover--collapsed{{ end }}" {{ if .Site.Params.cover }} style="background-image: url({{ .Site.Params.cover }})" {{ end }} id="scriptHeader">
+<header class="{{ if .IsNode }} {{ if eq .URL "/post/" }} panel-cover panel-cover--collapsed {{ else }}panel-cover {{ end }}{{ else }}panel-cover panel-cover--collapsed{{ end }}" {{ if .Site.Params.cover }} style="background-image: url({{ .Site.Params.cover }})" {{ end }} id="scriptHeader">
     <div class="panel-main">
         <div class="panel-main__inner panel-inverted">
             <div class="panel-main__content"> {{ if .Site.Params.logo }}
-                <a href="{{ .Site.BaseUrl }}" title="link to homepage for {{ .Site.Title }}"> <img src="{{ .Site.Params.logo }}" width="80" alt="{{ .Site.Title }} logo" class="panel-cover__logo logo" /> </a> {{ end }}
+                <a href="{{ .Site.BaseURL }}" title="link to homepage for {{ .Site.Title }}"> <img src="{{ .Site.Params.logo }}" width="80" alt="{{ .Site.Title }} logo" class="panel-cover__logo logo" /> </a> {{ end }}
                 <h1 class="panel-cover__title panel-title">
-                    <a href="{{ .Site.BaseUrl }}"  title="link to homepage for {{ .Site.Title }}">{{ .Site.Title }}</a>
+                    <a href="{{ .Site.BaseURL }}"  title="link to homepage for {{ .Site.Title }}">{{ .Site.Title }}</a>
                 </h1>
                 <hr class="panel-cover__divider" />
                 <p class="panel-cover__description"> {{ if .Site.Params.description }} {{ .Site.Params.description }} {{ else }} This site is built using <a href="http://gohugo.io">hugo</a> and the theme is built by <a href="http://fredrikloch.me">Fredrik</a> if you enjoy it, it is available at <a href="https://github.com/SenjinDarashiva/hugo-uno">github</a> {{end}} </p>
@@ -36,9 +36,9 @@
         <div class="panel-main">
             <div class="panel-main__inner panel-inverted">
                 <div class="panel-main__content"> {{ if .Site.Params.logo }}
-                    <a href="{{ .Site.BaseUrl }}" title="link to homepage for {{ .Site.Title }}"> <img src="{{ .Site.Params.logo }}" width="80" alt="{{ .Site.Title }} logo" class="panel-cover__logo logo" /> </a> {{ end }}
+                    <a href="{{ .Site.BaseURL }}" title="link to homepage for {{ .Site.Title }}"> <img src="{{ .Site.Params.logo }}" width="80" alt="{{ .Site.Title }} logo" class="panel-cover__logo logo" /> </a> {{ end }}
                     <h1 class="panel-cover__title panel-title">
-                        <a href="{{ .Site.BaseUrl }}"  title="link to homepage for {{ .Site.Title }}">{{ .Site.Title }}</a>
+                        <a href="{{ .Site.BaseURL }}"  title="link to homepage for {{ .Site.Title }}">{{ .Site.Title }}</a>
                     </h1>
                     <hr class="panel-cover__divider" />
                     <p class="panel-cover__description"> {{ if .Site.Params.description }} {{ .Site.Params.description }} {{ else }} This site is built using <a href="http://gohugo.io">hugo</a> and the theme is built by <a href="http://fredrikloch.me">Fredrik</a> if you enjoy it, it is available at <a href="https://github.com/SenjinDarashiva/hugo-uno">github</a> {{end}} </p>

--- a/layouts/shortcodes/relLink.html
+++ b/layouts/shortcodes/relLink.html
@@ -1,1 +1,1 @@
-<a href="{{ .Page.Site.BaseUrl }}/{{ index .Params 0 }}">{{ index .Params 1 }}</a>
+<a href="{{ .Page.Site.BaseURL }}/{{ index .Params 0 }}">{{ index .Params 1 }}</a>


### PR DESCRIPTION
This has two fixes.

1. Deprecated names changed: BaseUrl -> BaseURL, Url -> URL
2. Fix voor sites that are not located at /

I am not sure if and how number 2 needs more fixes, like in this code fragment:

    {{ if eq .URL "/post/" }}
   
