### PR TITLE
Fix link problem

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -26,7 +26,7 @@
                 <div class="navigation-wrapper">
                     <nav class="cover-navigation cover-navigation--primary">
                         <ul class="navigation">
-                            <li class="navigation__item"><a href="{{ .Site.BaseURL }}/#blog" title="link to {{ .Site.Title }} blog" class="blog-button">Blog</a> </li>
+                            <li class="navigation__item"><a href="{{ .Site.BaseURL }}#blog" title="link to {{ .Site.Title }} blog" class="blog-button">Blog</a> </li>
                             </br> {{ if .Site.Params.cv }}
                             <li class="navigation__item"><a href="{{ .Site.Params.cv  }}" title="link to my CV " class="blog-button">CV</a> </li>
                             </br> {{ end }} </ul>


### PR DESCRIPTION
On here, if we click the `a.blog-button`, we were redirected to `http://themes.gohugo.io/theme/hugo-uno//#blog`. Removed a `/`.