### PR TITLE
Corrected CLI Commands in README / Added Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'sass', '~>3.3.4'
+gem 'bourbon', '~>3.1.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bourbon (3.1.8)
+      sass (>= 3.2.0)
+      thor
+    sass (3.3.14)
+    thor (0.19.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bourbon (~> 3.1.8)
+  sass (~> 3.3.4)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To check installation run the following commands from a terminal and you should 
 sass -v
 > Sass 3.3.4 (Maptastic Maple)
 ```
-If for some reason SASS isn't installed follow the instructions from the [Sass install page](http://sass-lang.com/install)
+If for some reason SASS isn't installed then either follow the instructions from the [Sass install page](http://sass-lang.com/install) or run `bundle install` in the project root.
 
 ** Bourbon **
 ```bash
@@ -147,25 +147,25 @@ If for some reason SASS isn't installed follow the instructions from the [Sass i
 bourbon help
 > Bourbon 3.1.8
 ```
-If Bourbon isn't installed follow the installation instructions on the [Bourbon website](http://bourbon.io)
+If Bourbon isn't installed follow the installation instructions on the [Bourbon website](http://bourbon.io) or run `bundle install` in the project root.
 
 Once installation is verified we will need to go mount the bourbon mixins into the `scss` folder.
 
 From the project root run `bourbon install` with the correct path
 ```bash
-bourbon install --path assets/scss
-> bourbon files installed to assets/scss/bourbon/
+bourbon install --path static/scss
+> bourbon files installed to static/scss/bourbon/
 ```
 
 Now that we have the bourbon mixins inside of the `scss` src folder we can now use the sass cli command to watch the scss files for changes and recompile them.
 
 ```bash
-sass --watch assets/scss:assets/css
+sass --watch static/scss:static/css
 >>>> Sass is watching for changes. Press Ctrl-C to stop.
 ```
 
-To minify the css files use the following command in the assets folder
+To minify the css files use the following command in the static folder
 
 ```bash
-curl -X POST -s --data-urlencode 'input@css/uno.css' http://cssminifier.com/raw > css/uno.min.css
+curl -X POST -s --data-urlencode 'input@static/css/uno.css' http://cssminifier.com/raw > static/css/uno.min.css
 ```


### PR DESCRIPTION
I tripped up a bit when trying to follow the development steps in the README, which I realised was because the CLI commands included the wrong paths ("assets" -> "static"). I've corrected these in the README and also added a Gemfile so developers can use Bundler to install any missing gems.